### PR TITLE
Rewrite fleet algorithm

### DIFF
--- a/api/controllers/SystemController.js
+++ b/api/controllers/SystemController.js
@@ -37,7 +37,8 @@ module.exports = {
     for (let fleet of fleets) {
       let resolvedFleet = await FleetSerializer.one(fleet.id);
 
-      resolvedFleets.push(resolvedFleet);
+      if (resolvedFleet.characters.length)
+        resolvedFleets.push(resolvedFleet);
     }
 
     // Subscribe sockets to future system updates.

--- a/api/models/Fleet.js
+++ b/api/models/Fleet.js
@@ -41,7 +41,11 @@ module.exports = {
 
     characters: { collection: 'character', via: 'fleet' },
 
-    kills: { collection: 'kill', via: 'fleet' }
+    kills: { collection: 'kill', via: 'fleet' },
+
+    // Meta
+
+    meta: 'json'
 
   },
 

--- a/api/models/Kill.js
+++ b/api/models/Kill.js
@@ -17,7 +17,7 @@ module.exports = {
 
     positionName: 'string',
 
-    attackers: 'json',
+    composition: 'json',
 
     // Relationships
 

--- a/api/models/Kill.js
+++ b/api/models/Kill.js
@@ -17,6 +17,8 @@ module.exports = {
 
     positionName: 'string',
 
+    attackers: 'json',
+
     // Relationships
 
     ship: { model: 'type' },

--- a/api/services/Resolver.js
+++ b/api/services/Resolver.js
@@ -39,8 +39,6 @@ let Resolver = {
 
   async composition(ids, characters) {
 
-    sails.log.debug(`[Resolver.composition] Begin`);
-
     // ids: [] of pilots { character_id, ship_type_id }
     // characters: [] of character records
 
@@ -60,8 +58,6 @@ let Resolver = {
       if (charIndex !== -1)
         characters[charIndex].ship = resolvedShipTypes[shipIndex];
     });
-
-    sails.log.debug(`[Resolver.composition] End`);
 
     return characters;
   }

--- a/api/services/Resolver.js
+++ b/api/services/Resolver.js
@@ -8,6 +8,12 @@
 let Resolver = {
 
   async position(position, systemId) {
+    if (!position || !systemId) {
+      sails.log.error('[Resolver] ESI failure: Incomplete position data');
+
+      return 'Unknown';
+    }
+
     let response;
 
     try {

--- a/api/services/ZkillPush.js
+++ b/api/services/ZkillPush.js
@@ -37,8 +37,13 @@ module.exports = {
         json: true
       }, async(error, response, body) => {
         if (error) {
+          if (!response || !response.statusCode) {
+            sails.log.error(`[ZkillPush.fetch] No response from RedisQ.`);
+            return resolve();
+          }
+
           sails.log.error(`[ZkillPush.fetch] ${response.statusCode} ${error}`);
-          return reject();
+          return resolve();
         }
 
         // Sometimes the service returns null, see: https://github.com/zKillboard/RedisQ

--- a/api/services/ZkillResolve.js
+++ b/api/services/ZkillResolve.js
@@ -24,7 +24,8 @@ module.exports = {
         character_id: characterId,
         position,
         ship_type_id: shipTypeId
-      }
+      },
+      attackers
     } = killmail;
 
     // Check for local record. If it exists, cancel further logic.
@@ -78,11 +79,14 @@ module.exports = {
         { id: system } = systemRes,
         positionName = positionRes;
 
+    attackers = attackers.map((a) => a.character_id);
+
     let kill = await Kill.create({
       killId,
       time,
       position,
       positionName,
+      attackers,
       ship,
       victim,
       system
@@ -96,8 +100,8 @@ module.exports = {
 
     let elapsedTime = now.diff(then, 'minutes');
 
-    if (process.env.TRACK_FLEETS === 'true' && elapsedTime < 30)
-      fleet = await Identifier.fleet(package.killmail, system, kill);
+    if (process.env.TRACK_FLEETS === 'true' && elapsedTime < parseInt(process.env.FLEET_EXPIRY_IN_MINUTES))
+      fleet = await Identifier.fleet(killmail, system, kill);
 
     kill = await Kill.findOne(kill.id)
       .populate('ship')

--- a/api/services/ZkillResolve.js
+++ b/api/services/ZkillResolve.js
@@ -79,14 +79,19 @@ module.exports = {
         { id: system } = systemRes,
         positionName = positionRes;
 
-    attackers = attackers.map((a) => a.character_id);
+    let composition = {};
+
+    attackers.map(({ character_id, ship_type_id }) => {
+      if (character_id !== undefined)
+        composition[character_id] = ship_type_id;
+    });
 
     let kill = await Kill.create({
       killId,
       time,
       position,
       positionName,
-      attackers,
+      composition,
       ship,
       victim,
       system

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -34,7 +34,7 @@ module.exports = {
       adapter: 'sails-mongo',
       host: '127.0.0.1',
       port: 27017,
-      database: 'sentinel_prod'
+      database: 'sentinel'
     },
 
   },

--- a/config/jobs.js
+++ b/config/jobs.js
@@ -40,7 +40,7 @@ function init() {
     let now = moment(),
         fiveMinutesAgo = now.subtract(5, 'minutes').toISOString();
 
-    Fleet.find({ isActive: true, updatedAt: { '<=' : fiveMinutesAgo } })
+    Fleet.find({ isActive: true, updatedAt: { '>=' : fiveMinutesAgo } })
       .limit(50)
       .then(async(fleets) => {
         for (let fleet of fleets) {
@@ -84,10 +84,7 @@ function init() {
 
           await Fleet.update(fleet.id, { dangerRatio });
 
-          let system = await System.findOne(fleet.system);
-
-          fleet.system = system;
-          fleet.dangerRatio = dangerRatio;
+          fleet = await FleetSerializer.one(fleet.id);
 
           Dispatcher.notifySockets(fleet, 'fleet');
         }


### PR DESCRIPTION
- New Fleet attr: `meta`
- New Kill attr: `composition`
- Significantly improved fleet tracking logic
- Significantly improved code cleanliness
- Improved Zkill error handling
- Removed the concept of fleet merging (we simply move characters around and let the fleets die of inactivity)
- Only broadcast fleets with active characters to connected sockets
- Fix fleet threat calculation jobs
- Run all fleet broadcasts through the FleetSerializer